### PR TITLE
Added async command best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,18 @@ public class RepositoryViewModel : ReactiveObject
     Delete.IsExecuting.ToProperty(this, x => x.IsDeleting, out _isDeleting);
     Delete.ThrownExceptions.Subscribe(ex => /*...*/);
   }
+  
+  public string RepositoryId { get; private set; }
 
   public ReactiveCommand<Unit> Delete { get; private set; }
   
   readonly ObservableAsPropertyHelper<bool> _isDeleting;
   public bool IsDeleting { get { return _isDeleting.Value; } }
 
-  public IObservable<Unit> DeleteImpl() {...}
+  public IObservable<Unit> DeleteImpl()
+  {
+    return Observable.Start(() => _repositoryService.Delete(RepositoryId));
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ public class RepositoryViewModel : ReactiveObject
   {
     Delete = ReactiveCommand.CreateAsyncObservable(x => DeleteImpl());
     Delete.IsExecuting.ToProperty(this, x => x.IsDeleting, out _isDeleting);
-    Delete.ThrownExceptions.Subscribe(ex => /*...*/);
+    Delete.ThrownExceptions.Subscribe(ex => this.Log().ErrorException("Something went wrong", ex));
   }
   
   public string RepositoryId { get; private set; }
@@ -123,7 +123,7 @@ public class RepositoryViewModel : ReactiveObject
     Delete.Subscribe(async _ => await DeleteImpl());
     // These will not do what you expect
     Delete.IsExecuting.ToProperty(this, x => x.IsDeleting, out _isDeleting);
-    Delete.ThrownExceptions.Subscribe(ex => /*...*/);
+    Delete.ThrownExceptions.Subscribe(ex => this.Log().ErrorException("Something went wrong", ex));
   }
 
   public ReactiveCommand<object> Delete { get; private set; }

--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ public class RepositoryViewModel : ReactiveObject
     Delete.IsExecuting.ToProperty(this, x => x.IsDeleting, out _isDeleting);
     Delete.ThrownExceptions.Subscribe(ex => this.Log().ErrorException("Something went wrong", ex));
   }
-  
-  public string RepositoryId { get; private set; }
 
   public ReactiveCommand<Unit> Delete { get; private set; }
   
@@ -103,7 +101,7 @@ public class RepositoryViewModel : ReactiveObject
 
   public IObservable<Unit> DeleteImpl()
   {
-    return Observable.Start(() => _repositoryService.Delete(RepositoryId));
+    return Observable.Start(() => /* ... */);
   }
 }
 ```
@@ -131,7 +129,10 @@ public class RepositoryViewModel : ReactiveObject
   readonly ObservableAsPropertyHelper<bool> _isDeleting;
   public bool IsDeleting { get { return _isDeleting.Value; } }
 
-  public IObservable<Unit> DeleteImpl() {...}
+  public IObservable<Unit> DeleteImpl()
+  {
+    return Observable.Start(() => /* ... */);
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ When a `ReactiveCommand`'s implementation is too large or too complex for an ano
 
 ### Async Commands
 
-Prefer using async `ReactiveCommand`'s over the more basic `ReactiveCommand` for all but the most simple tasks.
+Prefer using async `ReactiveCommand`'s over the more basic `ReactiveCommand` for all but the most simple tasks. In ReactiveUI, you should never put Interesting™ code inside the Subscribe block - Subscribe is solely to log the result of operations, or to wire up properties to other properties.
 
 __Do__
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ public class RepositoryViewModel : ReactiveObject
 
 A lot of the power of `ReactiveCommand` comes from the async version. In the basic version the following features do not function as expected:
 
-* `IsExecuting` observable does not include any user code.
+* `IsExecuting` observable will not report on your asynchronous method when it is inside the `Subscribe`
 * `ThrownExceptions` will not catch anything.
 * `CanExecute` is not affected if the command is currently executing, leading to the possibilty of multiple execution at the same time.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Synchronize = ReactiveCommand.CreateAsyncObservable(
 
 When a `ReactiveCommand`'s implementation is too large or too complex for an anonymous delegate, name the implementation's method the same name as the command, but with `Impl` suffixed (for example, `SychronizeImpl` above).
 
-### Async Commands
+### Asynchronous Commands
 
 Prefer using async `ReactiveCommand`'s over the more basic `ReactiveCommand` for all but the most simple tasks. In ReactiveUI, you should never put Interesting™ code inside the Subscribe block - Subscribe is solely to log the result of operations, or to wire up properties to other properties.
 


### PR DESCRIPTION
The difference between the typical `ReactiveCommand.Create()` and the async version `ReactiveCommand.CreateAsyncObservable()`, or its brethren, can be confusing to new users. I wanted to spell out the differences.